### PR TITLE
Open access to deployment id for extensions

### DIFF
--- a/core/src/main/java/org/camunda/bpm/extension/junit5/test/ProcessEngineExtension.java
+++ b/core/src/main/java/org/camunda/bpm/extension/junit5/test/ProcessEngineExtension.java
@@ -63,7 +63,7 @@ public class ProcessEngineExtension implements TestWatcher,
   
   protected String configurationResource = "camunda.cfg.xml";
   
-  private String deploymentId;
+  protected String deploymentId;
 
   public final static List<String> RESOURCE_SUFFIXES = new ArrayList<>();
 
@@ -96,6 +96,10 @@ public class ProcessEngineExtension implements TestWatcher,
 
   public ProcessEngineConfigurationImpl getProcessEngineConfiguration() {
     return processEngineConfiguration;
+  }
+
+  public String getDeploymentId() {
+    return deploymentId;
   }
 
   @Override

--- a/core/src/test/java/org/camunda/bpm/extension/junit5/ProcessEngineExtensionDeploymentIdAccess.java
+++ b/core/src/test/java/org/camunda/bpm/extension/junit5/ProcessEngineExtensionDeploymentIdAccess.java
@@ -1,0 +1,59 @@
+package org.camunda.bpm.extension.junit5;
+
+import org.camunda.bpm.extension.junit5.test.ProcessEngineExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * @author Martin Schimak
+ */
+public class ProcessEngineExtensionDeploymentIdAccess {
+
+  @Test
+  public void testDeploymentIdWriteableForExtensions() {
+
+    class ProcessEngineExtensionExtension extends org.camunda.bpm.extension.junit5.test.ProcessEngineExtension {
+
+      @Override
+      public void beforeTestExecution(ExtensionContext context) {
+        // here I could decide to override the way the deployment is created, e.g.
+        // add mocked call activities etc, therefore I need deploymentId accessible
+        // Note: in case the write access is removed, this will not compile anymore
+        this.deploymentId = "xyz";
+      }
+
+    }
+
+  }
+
+
+  @Test
+  public void testDeploymentIdReadableForExtensionsAndWrappers() {
+
+    class ProcessEngineExtensionExtension extends org.camunda.bpm.extension.junit5.test.ProcessEngineExtension {
+
+      @Override
+      public void afterTestExecution(ExtensionContext context) {
+        // here I could decide to override the way the deployment is removed
+        // Note: in case the write access is removed, this will not compile anymore
+        String deploymentId = this.deploymentId;
+      }
+
+    }
+
+    class ProcessEngineExtensionWrapper {
+
+      ProcessEngineExtension wrapped = ProcessEngineExtension.builder().build();
+
+      {
+        // here I could decide to access the deployment. e.g. to look at the
+        // runtime or history data of the current deployment before it is removed
+        // Note: in case this read access is removed, this will not compile anymore
+        String deploymentId = wrapped.getDeploymentId();
+      }
+
+    }
+
+  }
+
+}


### PR DESCRIPTION
Hi all, to enable extensions which need access to deployment infos before undeployment already happened (e.g. for test reports) I would ask you to open the access to the (currently "private") deployment id. I suggest to have public read access and write access for extensions. And it would be awesome if you could release this as 1.0.2. 😄 Thank you! 🙏